### PR TITLE
Mairold camera launcher multi image fix

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -699,7 +699,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
 
     /**
-     * Applies all needed transformation to the image received from the gallery.
+     * Applies all needed transformation to the image received from the gallery. Currently limited to three media files, but can be easily modified.
      *
      * @param destType In which form should we return the image
      * @param intent   An Intent, which can return result data to the caller (various data can be attached to Intent "extras").
@@ -715,7 +715,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             while (index != counter) {
                 uriList.add(intent.getClipData().getItemAt(index).getUri());
                 index++;
-                if (index == 3) {
+                if (index == 3) // Number "3" limits the selected content from gallery to 3. First three media files are processed.
+                {
                     break;
                 }
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
Api did not allow to select multiple media files from  library. It was possible to export media from device library one by one.



### Description
Api was built so that it would get single Uri from Intent , process the Uri and send back to caller in required type (DATA_URL or FILE_URI). 
Changes were made mainly in processResultFromGallery function. After changes it checks if Intent has single Uri or multiple Uris. Gathers them and puts into List of Uris. After that depending on the required destType (URL or URI) the Uris are processed one by one and results (URL Base64 String or URI filepath) are put into JSONArray which is then returned to caller with callbackContext. 

Minimal changes were made also in other  functions in order for the multi media select to work. 

### Testing
MediaType == Photo changes were tested through debugging process and manual testing on the device. 
Debugging showed that both DATA_URL and File_URL are successfully gathered to JSONArray and sent out to caller.

As caller was set up to only process first BASE64 of List then only first picture appears to UI. Technically with little change all pictures can appear on caller side.

MediaType == Video is not tested but technically  should work. Will return JSONArray containing files real paths.(Uris)



### Checklist

None of below is properly checked :)
- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
